### PR TITLE
systemd-boot support

### DIFF
--- a/install
+++ b/install
@@ -11,9 +11,13 @@ QUIRK_VAL="0x4d9:0x1400:0x4"
 QUIRK_PARAM="usbhid.quirks=$QUIRK_VAL"
 
 if ! fgrep -q " $QUIRK_PARAM" /proc/cmdline ; then
+    # checks which config file is present to figure out what bootloader is used
+    # then stores the file's location and where to add kernel command line parameters in it
+    # GRUB
     if [ -e /etc/default/grub ]; then
         CONFIG_LOC="/etc/default/grub"
         OPTIONS_LINE='/^(GRUB_CMDLINE_LINUX_DEFAULT=".*)("\s*$)/'
+    # systemd-boot
     elif [ -e /boot/loader/entries/arch.conf ]; then
         CONFIG_LOC="/boot/loader/entries/arch.conf"
         OPTIONS_LINE='/^(options.*)(\s*$)/'

--- a/install
+++ b/install
@@ -12,29 +12,35 @@ QUIRK_PARAM="usbhid.quirks=$QUIRK_VAL"
 
 if ! fgrep -q " $QUIRK_PARAM" /proc/cmdline ; then
     if [ -e /etc/default/grub ]; then
-	if ! fgrep -q " $QUIRK_PARAM" /etc/default/grub ; then
-	    # Install
-	    echo "Setup kernel cmdline to not use usbhid module for our mouse.."
-	    if ! perl -i.usbmouse-bak -e '
-    while(<>) {
-      if (/^(GRUB_CMDLINE_LINUX_DEFAULT=".*)("\s*$)/) {
-        my ($x,$y)=($1,$2);
-        $found=1;
-        if ($x !~ m!usbhid.quirks!) {
-          $_ = $x." '"$QUIRK_PARAM"'".$y;
-        }
-      }
-      print;
-    }
-    exit(1) unless($found);
-  ' /etc/default/grub ; then
-		echo "ERROR: Failed to patch kernel cmdline!"
-		exit 1
-	    fi
-	fi
+        CONFIG_LOC="/etc/default/grub"
+        OPTIONS_LINE='/^(GRUB_CMDLINE_LINUX_DEFAULT=".*)("\s*$)/'
+    elif [ -e /boot/loader/entries/arch.conf ]; then
+        CONFIG_LOC="/boot/loader/entries/arch.conf"
+        OPTIONS_LINE='/^(options.*)(\s*$)/'
     else
-	echo "ERROR: Update this script to support patching wherever the kernel command line arguments should go"
-	exit 1
+        echo "ERROR: Update this script to support patching wherever the kernel command line arguments should go"
+        exit 1
+    fi
+
+    if ! fgrep -q " $QUIRK_PARAM" $CONFIG_LOC ; then
+    # Install
+    echo "Setup kernel cmdline to not use usbhid module for our mouse.."
+        if ! perl -i.usbmouse-bak -e '
+        while(<>) {
+          if ('$OPTIONS_LINE') {
+            my ($x,$y)=($1,$2);
+            $found=1;
+            if ($x !~ m!usbhid.quirks!) {
+              $_ = $x." '"$QUIRK_PARAM"'".$y;
+            }
+          }
+          print;
+        }
+        exit(1) unless($found);
+      ' $CONFIG_LOC ; then
+    	    echo "ERROR: Failed to patch kernel cmdline!"
+    	    exit 1
+	fi
     fi
 fi
 


### PR DESCRIPTION
After verifying if the kernel commandline was patched, it checks which config file is present, stores its location in **CONFIG_LOC** and sets the if condition (inside the loop in the perl bit) for finding the line where the parameters are in **OPTIONS_LINE**.

I implemented it that way since I thought it might make it easier for anyone wanting to patch it further.